### PR TITLE
Navigation Flow Fixes for iOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'COVID-19 Tracker',
       theme: ThemeData(
         // This is the theme of your application.
         //
@@ -21,92 +21,14 @@ class MyApp extends StatelessWidget {
         // is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: WelcomeScreen(),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  _MyHomePageState createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.display1,
-            ),
-          ],
+      home: Scaffold(
+        appBar: AppBar(
+          title: Text('COVID-19 Tracker'),
+        ),
+        body: Center(
+          child: WelcomeScreen(),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/page/screen/case_details_screen.dart
+++ b/lib/page/screen/case_details_screen.dart
@@ -6,6 +6,10 @@ class CaseDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+          title: Text(
+        "Case Details",
+      )),
       body: Center(
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -15,7 +19,10 @@ class CaseDetailScreen extends StatelessWidget {
             color: Colors.blue,
             child: Text("User register"),
             onPressed: () {
-              Navigator.push(context, createRoute(UserRegisterScreen()));
+              Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => UserRegisterScreen()));
             },
           )
         ],

--- a/lib/page/screen/case_list_screen.dart
+++ b/lib/page/screen/case_list_screen.dart
@@ -6,6 +6,9 @@ class CaseListScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text("Case List"),
+      ),
       body: Center(
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -15,7 +18,8 @@ class CaseListScreen extends StatelessWidget {
             color: Colors.green,
             child: Text("Select Case"),
             onPressed: () {
-              Navigator.push(context, createRoute(CaseDetailScreen()));
+              Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => CaseDetailScreen()));
             },
           ),
         ],

--- a/lib/page/screen/dashboard_screen.dart
+++ b/lib/page/screen/dashboard_screen.dart
@@ -7,6 +7,9 @@ class DashboardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text("Dashboard"),
+      ),
       body: Center(
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -16,14 +19,16 @@ class DashboardScreen extends StatelessWidget {
             color: Colors.green,
             child: Text("Select News"),
             onPressed: () {
-              Navigator.push(context, createRoute(NewsDetailScreen()));
+              Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => NewsDetailScreen()));
             },
           ),
           FlatButton(
             color: Colors.blue,
             child: Text("Case List Screen"),
             onPressed: () {
-              Navigator.push(context, createRoute(CaseListScreen()));
+              Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => CaseListScreen()));
             },
           )
         ],

--- a/lib/page/screen/news_details_screen.dart
+++ b/lib/page/screen/news_details_screen.dart
@@ -4,6 +4,9 @@ class NewsDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text("News Details"),
+      ),
       body: Center(
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/page/screen/privacy_policy_screen.dart
+++ b/lib/page/screen/privacy_policy_screen.dart
@@ -4,6 +4,9 @@ class PrivacyPolicyScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text("Privacy Policy"),
+      ),
       body: Center(
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/page/screen/user_register_screen.dart
+++ b/lib/page/screen/user_register_screen.dart
@@ -4,6 +4,9 @@ class UserRegisterScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text("User Registration"),
+      ),
       body: Center(
           child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/page/screen/welcome_screen.dart
+++ b/lib/page/screen/welcome_screen.dart
@@ -18,13 +18,17 @@ class WelcomeScreen extends StatelessWidget {
             color: Colors.amber,
             child: Text("Home Screen"),
             onPressed: () {
-              Navigator.push(context, createRoute(DashboardScreen()));
+              Navigator.push(context,
+                  MaterialPageRoute(builder: (context) => DashboardScreen()));
             },
           ),
           FlatButton(
             child: Text("Privacy Policy Screen"),
             onPressed: () {
-              Navigator.push(context, createRoute(PrivacyPolicyScreen()));
+              Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => PrivacyPolicyScreen()));
             },
           )
         ],


### PR DESCRIPTION
* Added an app bar for each screen so that you have the back button to go back in the navigation flow
* Changed all navigation pushes to use MaterialPageRoute so that you can swipe back to the previous screen
* Removed boilerplate code from main.dart