### PR TITLE
moving the map to the case location on load

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -75,9 +75,9 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
-  - geolocator (5.3.0):
+  - geolocator (5.3.1):
     - Flutter
-  - google_api_availability (2.0.3):
+  - google_api_availability (2.0.4):
     - Flutter
   - google_maps_flutter (0.0.1):
     - Flutter
@@ -147,6 +147,8 @@ PODS:
     - Flutter
   - url_launcher_web (0.0.1):
     - Flutter
+  - webview_flutter (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - connectivity (from `.symlinks/plugins/connectivity/ios`)
@@ -170,6 +172,7 @@ DEPENDENCIES:
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
   - url_launcher_macos (from `.symlinks/plugins/url_launcher_macos/ios`)
   - url_launcher_web (from `.symlinks/plugins/url_launcher_web/ios`)
+  - webview_flutter (from `.symlinks/plugins/webview_flutter/ios`)
 
 SPEC REPOS:
   trunk:
@@ -236,6 +239,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_macos/ios"
   url_launcher_web:
     :path: ".symlinks/plugins/url_launcher_web/ios"
+  webview_flutter:
+    :path: ".symlinks/plugins/webview_flutter/ios"
 
 SPEC CHECKSUMS:
   connectivity: 6e94255659cc86dcbef1d452ad3e0491bb1b3e75
@@ -255,8 +260,8 @@ SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   flutter_plugin_android_lifecycle: 47de533a02850f070f5696a623995e93eddcdb9b
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  geolocator: 7cdcf71180b80913b3cd84ab715d3b5365b378af
-  google_api_availability: 526574c9a5a0ae541e18c65f98e47afc11f53c8b
+  geolocator: 460cc8e850b616f8c0e90944c86517d91ccbb686
+  google_api_availability: 15fa42a8cd83c0a6738507ffe6e87096f12abcb8
   google_maps_flutter: d0dd62f5a7d39bae61057eb9f52dd778d99c7c6c
   GoogleAppMeasurement: 434cc7be25e71dc04b8d0e3079125127b330e84a
   GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
@@ -278,6 +283,7 @@ SPEC CHECKSUMS:
   url_launcher: a1c0cc845906122c4784c542523d8cacbded5626
   url_launcher_macos: fd7894421cd39320dce5f292fc99ea9270b2a313
   url_launcher_web: e5527357f037c87560776e36436bf2b0288b965c
+  webview_flutter: bec7599de6bfbe8008a739aa3ebd7b364ea9d0cd
 
 PODFILE CHECKSUM: 1b66dae606f75376c5f2135a8290850eeb09ae83
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+    <key>CFBundleDisplayName</key>
+    <string>MyHealth Sri Lanka</string>
 	<key>CFBundleName</key>
 	<string>MyHealth Sri Lanka</string>
 	<key>CFBundlePackageType</key>

--- a/lib/page/screen/contact_us_screen.dart
+++ b/lib/page/screen/contact_us_screen.dart
@@ -7,11 +7,8 @@ import 'package:selftrackingapp/app_localizations.dart';
 import 'package:selftrackingapp/models/contact_us_contact.dart';
 import 'package:selftrackingapp/networking/data_repository.dart';
 import 'package:selftrackingapp/utils/tracker_colors.dart';
-import 'package:selftrackingapp/widgets/custom_text.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:firebase_remote_config/firebase_remote_config.dart';
 
-import '../../theme.dart';
 import '../../utils/tracker_colors.dart';
 
 class ContactUsScreen extends StatefulWidget {
@@ -20,37 +17,7 @@ class ContactUsScreen extends StatefulWidget {
 }
 
 class _ContactUsScreenState extends State<ContactUsScreen> {
-  RemoteConfig remoteConfig;
-  bool medicalConsultationAccess = false;
-
-  final defaultConfigs = <String, dynamic>{
-    'medical_consultation_access': false
-  };
-
-  @override
-  void initState() {
-    RemoteConfig.instance.then((config) {
-      setState(() {
-        remoteConfig = config;
-        remoteConfig.setDefaults(defaultConfigs).then((val) {
-          remoteConfig
-              .fetch(expiration: const Duration(seconds: 0))
-              .then((val) {
-            remoteConfig.activateFetched().then((val) {
-              setState(() {
-                print(remoteConfig
-                    .getValue("medical_consultation_access")
-                    .asBool());
-                medicalConsultationAccess =
-                    remoteConfig.getBool("medical_consultation_access");
-                print("Got update $medicalConsultationAccess");
-              });
-            });
-          });
-        });
-      });
-    });
-  }
+  bool medicalConsultationAccess = true;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/page/screen/selected_case_detail_screen.dart
+++ b/lib/page/screen/selected_case_detail_screen.dart
@@ -8,8 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:selftrackingapp/models/location.dart';
 import 'package:selftrackingapp/models/reported_case.dart';
-import 'package:selftrackingapp/widgets/case_item.dart';
-import 'package:selftrackingapp/widgets/custom_text.dart';
 
 DateFormat dateFormat = DateFormat("yyyy-MM-dd HH:mm:ss");
 
@@ -28,13 +26,22 @@ class _SelectedCaseDetailScreenState extends State<SelectedCaseDetailScreen> {
   static const MethodChannel _channel = MethodChannel('location');
 
   Completer<GoogleMapController> _controller = Completer();
-  Position currentLocation;
+  Position _currentLocation;
 
   List<Marker> locationMarkers = [];
 
   @override
   void initState() {
     super.initState();
+
+//    initializing _currentLocation with first location of the reported case
+    try {
+      _currentLocation = Position(
+          latitude: widget.reportedCase.locations[0].latitude,
+          longitude: widget.reportedCase.locations[0].longitude);
+    } catch (e) {
+      print(e);
+    }
 
 //    http://localhost:8000/application/dhis/patients
 
@@ -113,8 +120,8 @@ class _SelectedCaseDetailScreenState extends State<SelectedCaseDetailScreen> {
               strokeWidth: 0);
         }).toSet(),
         initialCameraPosition: CameraPosition(
-          target: currentLocation != null
-              ? LatLng(currentLocation.latitude, currentLocation.longitude)
+          target: _currentLocation != null
+              ? LatLng(_currentLocation.latitude, _currentLocation.longitude)
               : LatLng(6.9271, 79.8612),
           zoom: 12,
         ),


### PR DESCRIPTION
## Purpose
The purpose of this PR is to:

fix #180 
moving the map to the case location on load
added the key `CFBundleDisplayName` to `Info.plist` to prevent crash at launch in iOS

fix #178
Removed Fireabase cloud config fetch for medicalConsultationAccess and made it true by default
