### PR TITLE
Implemented version checking

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -75,9 +75,9 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
-  - geolocator (5.3.1):
+  - geolocator (5.3.0):
     - Flutter
-  - google_api_availability (2.0.4):
+  - google_api_availability (2.0.3):
     - Flutter
   - google_maps_flutter (0.0.1):
     - Flutter
@@ -260,8 +260,8 @@ SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   flutter_plugin_android_lifecycle: 47de533a02850f070f5696a623995e93eddcdb9b
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  geolocator: 460cc8e850b616f8c0e90944c86517d91ccbb686
-  google_api_availability: 15fa42a8cd83c0a6738507ffe6e87096f12abcb8
+  geolocator: 7cdcf71180b80913b3cd84ab715d3b5365b378af
+  google_api_availability: 526574c9a5a0ae541e18c65f98e47afc11f53c8b
   google_maps_flutter: d0dd62f5a7d39bae61057eb9f52dd778d99c7c6c
   GoogleAppMeasurement: 434cc7be25e71dc04b8d0e3079125127b330e84a
   GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,3 +1,11 @@
 final bool debugRelease = false;
 //final String testingServer = "https://test.covid-19.health.gov.lk/api";
 final String testingServer = "https://test.covid-19.health.gov.lk/api";
+
+//Constants defined for version checking
+const String ANDROID_APP_BUILD_NUMBER_KEY = "android_app_builder_number_Key";
+const String IOS_APP_BUILD_NUMBER_KEY = "ios_app_builder_number_key";
+const String ANDROID_APP_URL =
+    "https://play.google.com/store/apps/details?id=app.ceylon.selftrackingapp";
+const String IOS_APP_URL =
+    "https://apps.apple.com/us/app/myhealth-sri-lanka/id1503349513";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,25 +1,20 @@
 import 'dart:async';
 
-import 'dart:io';
-
-import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:connectivity/connectivity.dart';
+import 'package:dropdown_banner/dropdown_banner.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get_it/get_it.dart';
-import 'package:package_info/package_info.dart';
 import 'package:selftrackingapp/app_localizations.dart';
 import 'package:selftrackingapp/networking/data_repository.dart';
 import 'package:selftrackingapp/networking/db.dart';
 import 'package:selftrackingapp/page/screen/root_screen.dart';
 import 'package:selftrackingapp/page/screen/welcome_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:connectivity/connectivity.dart';
-import 'package:flutter/services.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'constants.dart';
+
 import 'utils/tracker_colors.dart';
-import 'package:dropdown_banner/dropdown_banner.dart';
 
 void main() {
   runApp(MyApp());
@@ -99,7 +94,6 @@ class _HomeScreenState extends State<HomeScreen> {
     });
 
     loadLang();
-    _appVersionCheck();
   }
 
   Future<void> loadLang() async {
@@ -159,101 +153,5 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     checkReachability();
     return _createSplashScreen();
-  }
-
-//check for the latest build number set in the firebase remote config
-//and show update dialog if necessary
-  void _appVersionCheck() async {
-    String key = Platform.isIOS
-        ? IOS_APP_BUILD_NUMBER_KEY
-        : ANDROID_APP_BUILD_NUMBER_KEY;
-
-    //Get Current buildNumber of the app
-    final PackageInfo info = await PackageInfo.fromPlatform();
-
-    //In Android this refers to [versionCode]. In iOS [CFBundleVersion]
-    int currentBuildNumber = int.parse(info.buildNumber);
-
-    //Get Latest version info from firebase config
-    final RemoteConfig remoteConfig = await RemoteConfig.instance;
-
-    try {
-      await remoteConfig
-          .setDefaults(<String, dynamic>{key: currentBuildNumber});
-
-      // Using default duration to force fetching from remote server.
-      await remoteConfig.fetch(expiration: const Duration(seconds: 0));
-      await remoteConfig.activateFetched();
-
-      int remoteBuildNumber = remoteConfig.getInt(key);
-
-      print("remoteBuildNumber $remoteBuildNumber");
-      if (remoteBuildNumber > currentBuildNumber) {
-        _showUpdateDialog();
-      }
-    } on FetchThrottledException catch (exception) {
-      // Fetch throttled.
-      print(exception);
-    } catch (exception) {
-      print('Unable to fetch remote config. Default value will be used');
-    }
-  }
-
-  void _showUpdateDialog() async {
-    bool isIOS = Platform.isIOS;
-    String title = "New Update Available";
-    String message =
-        "There is a newer version of the app available. Please update now.";
-    String affirmativeLabel = "Update Now";
-    String negativeLabel = "Later";
-
-    isIOS
-        ? showCupertinoDialog(
-            context: context,
-            builder: (context) {
-              return CupertinoAlertDialog(
-                title: Text(title),
-                content: Text(message),
-                actions: <Widget>[
-                  CupertinoDialogAction(
-                    isDefaultAction: true,
-                    child: Text(affirmativeLabel),
-                    onPressed: () => launchAppStore(IOS_APP_URL),
-                  ),
-                  CupertinoDialogAction(
-                    child: Text(negativeLabel),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
-              );
-            })
-        : showDialog(
-            context: context,
-            builder: (BuildContext context) {
-              return AlertDialog(
-                title: Text(title),
-                content: Text(message),
-                actions: <Widget>[
-                  FlatButton(
-                    child: Text(
-                      affirmativeLabel.toUpperCase(),
-                      style: TextStyle(color: Colors.blue),
-                    ),
-                    onPressed: () => launchAppStore(ANDROID_APP_URL),
-                  ),
-                  FlatButton(
-                    child: Text(negativeLabel.toUpperCase()),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
-              );
-            },
-          );
-  }
-
-  void launchAppStore(String url) async {
-    if (await canLaunch(url)) {
-      launch(url);
-    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: Self tracking app
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.14.0+31
+version: 1.14.0+32
 
 environment:
     sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #179 

## Known issue
The code runs twice, as the widget gets initialized twice (even before the implementation of version checking). Thus two dialogs appear on top of the other.

It is another issue mentioned here #192

## Work around
The issue is likely to be because of the the implementation of the DropdownBanner package. Because the following seems to fix it.

Change this:
```dart
MaterialApp(
//....
//....
home: DropdownBanner(
        child: HomeScreen(),
        navigatorKey: navigatorKey,
      ),
)
```
To:
```dart
MaterialApp(
//....
//....
home: HomeScreen(),
)
```
## Notes
@dewmal Before merging, Please create and assign respective values for the following in the firebase console remote config: 
`android_app_builder_number_Key`
`ios_app_builder_number_key`